### PR TITLE
Changed link to picture to an absolute one

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-![Open Source at Microsoft](/images/open-at-microsoft.png)
+![Open Source at Microsoft](https://github.com/microsoft/.github/blob/main/images/open-at-microsoft.png) 
 
 ## Get Involved
 


### PR DESCRIPTION
That's helpful, because GitHub mobile can't display pictures with relative paths:

![Screenshot_20211221_111428_com github android](https://user-images.githubusercontent.com/58633848/146912703-40035a59-50ed-49a9-95d4-cf3c61872965.jpg)
