### PR TITLE
Activate GitHub Policy Service (aka GitOps)

### DIFF
--- a/policies/platformcontext.yml
+++ b/policies/platformcontext.yml
@@ -1,0 +1,10 @@
+name: platform_context
+description: The context for GitOps platform, this will drive GitOps specific policies
+owner: 
+resource: repository
+where: 
+configuration:
+  platformContext:
+    active: true
+onFailure: 
+onSuccess:


### PR DESCRIPTION
1. This will only activate the service, to allow pushing org level policies
2. Will do today the push of mandatory files policies only for GitOps repos