### PR TITLE
Revert "Exclude ebpf-for-windows, reason -  they have the security file under…"

### DIFF
--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -174,6 +174,7 @@ where:
   || repository.name.equals("mssql-scripter", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("redux-dynamic-modules", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("mu_feature_config", StringComparison.InvariantCultureIgnoreCase)
+  || repository.name.equals("ebpf-for-windows", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("Microsoft-Cloud-App-Security", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("PowerApps-Samples", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("vswhere", StringComparison.InvariantCultureIgnoreCase)


### PR DESCRIPTION
Reverts microsoft/.github#29