### PR TITLE
Let's recommend LICENSE

### DIFF
--- a/policies/mandatory-file-License.yml
+++ b/policies/mandatory-file-License.yml
@@ -1,6 +1,6 @@
 # metadata
-name: This repo is missing a license file
-description: This is a config to check if LICENSE.MD is present in repo.
+name: This repo is missing a LICENSE file
+description: This is a config to check if a LICENSE is present in a repo.
 
 # filters
 resource: repository
@@ -315,10 +315,13 @@ where:
 # primitive configuration
 configuration:
     mandatoryFiles:
-     issueTitle: This repo is missing a license file
+     issueTitle: This repo is missing a LICENSE file
      issueBody: |
-            This repository is currently missing a LICENSE.MD file outlining its license. A license helps users understand how to use your project in a compliant manner. You can find the standard MIT license text at the Microsoft repo templates LICENSE file: https://github.com/microsoft/repo-templates/blob/main/shared/LICENSE.
-            If you would like to learn more about open source licenses, please visit the document at https://aka.ms/license. 
+            This repository is currently missing a LICENSE file.
+            
+            A license helps users understand how to use your project in a compliant manner. You can find the standard MIT license Microsoft uses at: https://github.com/microsoft/repo-templates/blob/main/shared/LICENSE.
+
+            If you would like to learn more about open source licenses, please visit the document at https://aka.ms/license (Microsoft-internal guidance).
      prTitle: Adding Microsoft LICENSE
      prBody: 
      file:


### PR DESCRIPTION
The current text implies the repository is missing a LICENSE.md file. It's rare at Microsoft to use a Markdown LICENSE file. Instead, we prefer the industry-accepted standard which tends to be a text file without extension named `LICENSE`.