### PR TITLE
CLA: filter out a repo

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -1,4 +1,4 @@
-name: Contributor License Agreement Policy 
+name: Contributor License Agreement Policy
 description: CLA policy file
 
 resource: repository

--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -2,6 +2,9 @@ name: Contributor License Agreement Policy
 description: CLA policy file
 
 resource: repository
+where:
+- |
+  '!repository.name.equals("CHERIoT", StringComparison.InvariantCultureIgnoreCase)' # this is a collaboration project not under an open source license
 
 configuration: 
    cla:

--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -4,7 +4,7 @@ description: CLA policy file
 resource: repository
 where:
 - |
-  '!repository.name.equals("CHERIoT", StringComparison.InvariantCultureIgnoreCase)' # this is a collaboration project not under an open source license
+  !repository.name.equals("CHERIoT", StringComparison.InvariantCultureIgnoreCase) # this is a collaboration project not under an open source license
 
 configuration: 
    cla:

--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -4,7 +4,7 @@ description: CLA policy file
 resource: repository
 where:
 - |
-  !repository.name.equals("CHERIoT", StringComparison.InvariantCultureIgnoreCase) # this is a collaboration project not under an open source license
+  !repository.name.equals("CHERIoT", StringComparison.InvariantCultureIgnoreCase)
 
 configuration: 
    cla:


### PR DESCRIPTION
The CHERIoT project is a collaboration that has an alternate license and should be excluded from the CLA system for the time being.