### PR TITLE
Remove OpenJDK mirror repos from having mandatory files in place.

### DIFF
--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -949,7 +949,6 @@ where:
   || repository.name.equals("appcenter-sampleapp-ios-swift", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("fundraising-and-engagement", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("simonhzh", StringComparison.InvariantCultureIgnoreCase)
-  || repository.name.equals("openjdk-jdk", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("elasticqueue", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("synckusto", StringComparison.InvariantCultureIgnoreCase)
   || repository.name.equals("license-checker-webpack-plugin", StringComparison.InvariantCultureIgnoreCase)


### PR DESCRIPTION
Our team would like to maintain a 1:1 mirror of the upstream sources of the OpenJDK where we do not commit to, ever.

We don't technically need to do this, of course, but it suits our workflow nicely and is plain and simple to understand in our view.

This bot would inject new commits into our mirrored 1:1 branches and make the history not 1:1 with our upstream community. With 4000+ forks of this repo, correcting the issue will mean breaking the downstream forks from our repo (I believe it would require a modified rebase operation forcibly pushed to remove the offending commits).

The OpenJDK maintains a unique repo for each of the versions it ships, and we follow this pattern as well with openjdk-jdk11u, openjdk-jdk17u, and others coming soon.