### PR TITLE
Ignore vscode-wiki from mandatory files policy

### DIFF
--- a/policies/mandatory-file-License.yml
+++ b/policies/mandatory-file-License.yml
@@ -5,6 +5,8 @@ description: This is a config to check if a LICENSE is present in a repo.
 # filters
 resource: repository
 where:
+- |
+  !repository.name.equals("vscode-wiki", StringComparison.InvariantCultureIgnoreCase) # A special repo that mirrors vscode.wiki to enable contributions
 
 # primitive configuration
 configuration:

--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -4,7 +4,8 @@ description: this policy will ensure the presence of important files in Microsof
 
 # filters
 resource: repository
-where:
+- |
+  !repository.name.equals("vscode-wiki", StringComparison.InvariantCultureIgnoreCase) # A special repo that mirrors vscode.wiki to enable contributions
 
 # primitive configuration
 configuration:

--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -4,6 +4,7 @@ description: this policy will ensure the presence of important files in Microsof
 
 # filters
 resource: repository
+where:
 - |
   !repository.name.equals("vscode-wiki", StringComparison.InvariantCultureIgnoreCase) # A special repo that mirrors vscode.wiki to enable contributions
 


### PR DESCRIPTION
This is a special repo that mirrors the vscode.wiki repository in order to enable contributions. We do not want these mandatory files to show up in the wiki tab of the vscode project.