### PR TITLE
Do not apply mandatory-files policy to openjdk sources

### DIFF
--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -7,10 +7,10 @@ resource: repository
 where:
 - |
   !repository.name.equals("openjdk-jdk", StringComparison.InvariantCultureIgnoreCase)
-  || !repository.name.equals("openjdk-jdk11u", StringComparison.InvariantCultureIgnoreCase)
-  || !repository.name.equals("openjdk-jdk17u", StringComparison.InvariantCultureIgnoreCase)
-  || !repository.name.equals("openjdk-jdk20u", StringComparison.InvariantCultureIgnoreCase)
-  || !repository.name.equals("openjdk-jdk21u", StringComparison.InvariantCultureIgnoreCase)
+  && !repository.name.equals("openjdk-jdk11u", StringComparison.InvariantCultureIgnoreCase)
+  && !repository.name.equals("openjdk-jdk17u", StringComparison.InvariantCultureIgnoreCase)
+  && !repository.name.equals("openjdk-jdk20u", StringComparison.InvariantCultureIgnoreCase)
+  && !repository.name.equals("openjdk-jdk21u", StringComparison.InvariantCultureIgnoreCase)
 
 # primitive configuration
 configuration:

--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -5,6 +5,12 @@ description: this policy will ensure the presence of important files in Microsof
 # filters
 resource: repository
 where:
+- |
+  !repository.name.equals("openjdk-jdk", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk11", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk17", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk20", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk21", StringComparison.InvariantCultureIgnoreCase)
 
 # primitive configuration
 configuration:

--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -7,10 +7,10 @@ resource: repository
 where:
 - |
   !repository.name.equals("openjdk-jdk", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk11", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk17", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk20", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk21", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk11u", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk17u", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk20u", StringComparison.InvariantCultureIgnoreCase)
+  ||!repository.name.equals("openjdk-jdk21u", StringComparison.InvariantCultureIgnoreCase)
 
 # primitive configuration
 configuration:

--- a/policies/mandatory-files.yml
+++ b/policies/mandatory-files.yml
@@ -7,10 +7,10 @@ resource: repository
 where:
 - |
   !repository.name.equals("openjdk-jdk", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk11u", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk17u", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk20u", StringComparison.InvariantCultureIgnoreCase)
-  ||!repository.name.equals("openjdk-jdk21u", StringComparison.InvariantCultureIgnoreCase)
+  || !repository.name.equals("openjdk-jdk11u", StringComparison.InvariantCultureIgnoreCase)
+  || !repository.name.equals("openjdk-jdk17u", StringComparison.InvariantCultureIgnoreCase)
+  || !repository.name.equals("openjdk-jdk20u", StringComparison.InvariantCultureIgnoreCase)
+  || !repository.name.equals("openjdk-jdk21u", StringComparison.InvariantCultureIgnoreCase)
 
 # primitive configuration
 configuration:


### PR DESCRIPTION
Our workflow requires that we mirror the upstream OpenJDK sources from their `master` branch to our `main` branch without any divergence. We then apply open-source Microsoft driven patches to a release branch, based off that mirrored `main` to build our binaries with.

We'd like to avoid diverging our `main` branch at all.