### PR TITLE
Adding exclusion for winforms-designer repo to mandatory License file

### DIFF
--- a/policies/mandatory-file-License.yml
+++ b/policies/mandatory-file-License.yml
@@ -7,6 +7,7 @@ resource: repository
 where:
 - |
   !repository.name.equals("vscode-wiki", StringComparison.InvariantCultureIgnoreCase) # A special repo that mirrors vscode.wiki to enable contributions
+  && !repository.name.equals("winforms-designer", StringComparison.InvariantCultureIgnoreCase) # Private repo for collaboration with third party control vendors. It uses VS Supplemental License. 
 
 # primitive configuration
 configuration:


### PR DESCRIPTION
https://github.com/microsoft/winforms-designer is a private Github repo which uses VS Supplemental License. This repo requires collaboration with 3rd party control vendors.