### PR TITLE
Add a line to profile page that encourages people with questions specific to repo to use issues rather than generic email

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,9 +7,9 @@ Right now, open communities are building amazing software together, and there ar
 * [Explore featured projects](https://opensource.microsoft.com/projects/)
 * [Explore open source jobs at Microsoft](https://careers.microsoft.com/us/en/search-results?keywords=open%20source)
 * [Apply for Azure credits for open source projects](https://opensource.microsoft.com/azure-credits)
-* Please use [repository issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue)
+* Use [repository issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue)
 and not [opensource@microsoft.com](mailto:opensource@microsoft.com) to ask questions specific to an individual Microsoft
-repository. 
+repository.
 
 Visit [opensource.microsoft.com](https://opensource.microsoft.com) to learn more!
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -9,7 +9,7 @@ Right now, open communities are building amazing software together, and there ar
 * [Apply for Azure credits for open source projects](https://opensource.microsoft.com/azure-credits)
 * Please use [repository issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue)
 and not [opensource@microsoft.com](mailto:opensource@microsoft.com) to ask questions specific to an individual Microsoft
-repository.
+repository. 
 
 Visit [opensource.microsoft.com](https://opensource.microsoft.com) to learn more!
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,6 +7,9 @@ Right now, open communities are building amazing software together, and there ar
 * [Explore featured projects](https://opensource.microsoft.com/projects/)
 * [Explore open source jobs at Microsoft](https://careers.microsoft.com/us/en/search-results?keywords=open%20source)
 * [Apply for Azure credits for open source projects](https://opensource.microsoft.com/azure-credits)
+* Please use [repository issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue)
+and not [opensource@microsoft.com](mailto:opensource@microsoft.com) to ask questions specific to an individual Microsoft
+repository.
 
 Visit [opensource.microsoft.com](https://opensource.microsoft.com) to learn more!
 


### PR DESCRIPTION
Add a line to profile page that encourages people with questions specific to repo to use issues rather than generic email