### PR TITLE
Add bot-for-go[bot] to CLA exclude list

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -37,6 +37,7 @@ configuration:
          - azuresdkciprbot
          - benrobot
          - blackrobot
+         - bot-for-go[bot]
          - CBL-Mariner-Bot
          - content-assistant[bot]
          - coreosbot


### PR DESCRIPTION
We have a GitHub app (https://github.com/apps/bot-for-go) which we’re using to automatically create pull requests in certain Microsoft repositories. 

See https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2253622 for more context.