### PR TITLE
Bypass CLA checks for Business Central Bot (GitHub App)

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -38,6 +38,7 @@ configuration:
          - benrobot
          - blackrobot
          - bot-for-go[bot]
+         - business-central-bot[bot]
          - CBL-Mariner-Bot
          - content-assistant[bot]
          - coreosbot


### PR DESCRIPTION
[Business Central Bot](https://github.com/apps/business-central-bot) is a newly added GitHub App used primarily is [BCApps](https://github.com/microsoft/BCApps) and [AL-Go](https://github.com/microsoft/AL-Go) repos to eliminate the need of PATs for various automations.