### PR TITLE
Bypass CLA checks for embeddedbot.

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -55,6 +55,7 @@ configuration:
          - dotnet-maestro-bot
          - dotnet-winget-bot
          - edtbot
+         - embeddedbot
          - engelbot
          - flinchbot
          - github-actions[bot]


### PR DESCRIPTION
This is used by, for example, vcpkg-tool releases: https://github.com/microsoft/vcpkg-tool/releases/tag/2025-04-07

The recent changes forbidding bots from pushing commits (as per https://docs.opensource.microsoft.com/security/tsg/default-rulesets/ ) forced it to start creating PRs instead, which now trigger clabot.