### PR TITLE
CLA: remove microsoft-golang-bot from exception list

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -78,7 +78,6 @@ configuration:
          - McCoyBot
          - meo-autobot
          - microsoft-github-policy-service[bot]
-         - microsoft-golang-bot
          - MicrosoftIssueBot
          - MixedRealitySpectatorViewBot
          - msftbot[bot]


### PR DESCRIPTION
This bot user has been deprecated and we've now switched to GitHub Apps: https://github.com/microsoft/go-lab/issues/152