### PR TITLE
Add hve-core-release-please bot to CLA policies

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -65,6 +65,7 @@ configuration:
          - github-actions[bot]
          - goodboyrobot
          - greenkeeper[bot]
+         - hve-core-release-please[bot]
          - inclusive-coding-bot
          - iotgwbot
          - jenfoxbot


### PR DESCRIPTION
This adds the `hve-core-release-please[bot]` GitHub App to the CLA bypass list.

## Context
The [`hve-core`](https://github.com/microsoft/hve-core) repository uses [release-please](https://github.com/googleapis/release-please) for automated releases. The bot creates release PRs automatically when commits are merged to `main`.

Currently, [PR #174](https://github.com/microsoft/hve-core/pull/174) (v1.1.0 release) is blocked because the CLA check is requesting the bot sign the CLA.

## Change
Adds `hve-core-release-please[bot]` to `policies/cla.yml` `bypassUsers` list