### PR TITLE
ci: Add 2 bots to CLA policies

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -79,6 +79,7 @@ configuration:
          - McCoyBot
          - meo-autobot
          - microsoft-github-policy-service[bot]
+         - microsoft-react-native-sdk[bot]
          - MicrosoftIssueBot
          - MixedRealitySpectatorViewBot
          - msftbot[bot]

--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -90,6 +90,7 @@ configuration:
          - ninjarobot
          - nzspambot
          - oberonbot
+         - office-ogx-auth-helper[bot]
          - officedocsbot
          - OhMyGuus-Bot
          - opbld15


### PR DESCRIPTION
We use a couple of bots for some of our repos:
- https://github.com/microsoft/fluentui-react-native
- https://github.com/microsoft/rnx-kit
- https://github.com/microsoft/react-native-macos (soon)
- https://github.com/microsoft/lage (soon)
- https://github.com/microsoft/beachball (soon)
- https://github.com/microsoft/workspace-tools (soon)

