### PR TITLE
Add aspire-repo-bot to CLA configuration

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -28,6 +28,8 @@ configuration:
          - ALGitHubBot
          - ansibleazurebot
          - anton-bot
+         - aspire-repo-bot
+         - aspire-repo-bot[bot]
          - ascforiotbot
          - audevbot
          - azclibot


### PR DESCRIPTION
@jeffwilcox - thanks for pointing me to the correct docs. This PR adds the `aspire-repo-bot` entry.