### PR TITLE
Add power-pages-github-app[bot] to CLA bypass users

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -107,6 +107,7 @@ configuration:
          - playwrightmachine
          - podman-desktop-bot
          - polymcbot
+         - power-pages-github-app[bot]
          - prmerger-test[bot]
          - pulumi-bot
          - PylanceBot


### PR DESCRIPTION
Adds `power-pages-github-app[bot]` to the `bypassUsers` list in `policies/cla.yml`.

### Context
This bot identity is used by the [microsoft/powerplatform-vscode](https://github.com/microsoft/powerplatform-vscode) repository to open automated PRs (e.g. Dependabot auto-fix PRs). An example is [microsoft/powerplatform-vscode#1559](https://github.com/microsoft/powerplatform-vscode/pull/1559), which was blocked because the CLA check did not recognize this bot identity.

Adding it alongside the other bot entries in the CLA policy so its PRs are not blocked on the CLA requirement.