### PR TITLE
Adding bot for CLA exemption

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -64,6 +64,7 @@ configuration:
          - embeddedbot
          - engelbot
          - flinchbot
+         - ghcp4a-bot[bot]
          - github-actions[bot]
          - goodboyrobot
          - greenkeeper[bot]


### PR DESCRIPTION
Our team owns this repo - https://github.com/microsoft/GitHub-Copilot-for-Azure and we are using this bot "ghcp4a-bot" for internal automation that creates PRs to other repos and the number files are definitely more than 2 and would like to add the bot for CLA exemption so we stop seeing the comments from microsoft-github-policy-service.