### PR TITLE
Add OssSecurityBot to CLA policy

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -103,6 +103,7 @@ configuration:
          - opbld27
          - openapi-sdkautomation[bot]
          - openpublishbuild
+         - OssSecurityBot
          - OutlookBot
          - pbicvbot
          - playwrightmachine


### PR DESCRIPTION
Adding a bot account to the CLA policy bypass.