### PR TITLE
Add microsoft-pr-metrics to CLA allow-list

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -83,6 +83,7 @@ configuration:
          - McCoyBot
          - meo-autobot
          - microsoft-github-policy-service[bot]
+         - microsoft-pr-metrics
          - microsoft-react-native-sdk[bot]
          - MicrosoftIssueBot
          - MixedRealitySpectatorViewBot


### PR DESCRIPTION
This pull request makes a minor update to the CLA policy configuration by adding a new bot to the list of allowed users.

* Added `microsoft-pr-metrics` to the allowed users list in `policies/cla.yml`