### PR TITLE
Remove "[bot]" for cchh-releasenotes-githubapp

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -144,7 +144,7 @@ configuration:
          - microsoft-playwright-automation[bot]
          - chatconfig-production[bot]
          - az-ai-foundry-release-please[bot]
-         - cchh-releasenotes-githubapp[bot]
+         - cchh-releasenotes-githubapp
 
       prohibitedCompanies:
          - msft


### PR DESCRIPTION
Remove [bot] suffix since the CLA policies were still being caught for the git hub app 