### PR TITLE
Update cla.yml

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -85,6 +85,7 @@ configuration:
          - meo-autobot
          - microsoft-github-policy-service[bot]
          - microsoft-pr-metrics
+         - microsoft-pr-metrics[bot]
          - microsoft-react-native-sdk[bot]
          - MicrosoftIssueBot
          - MixedRealitySpectatorViewBot


### PR DESCRIPTION
Adding in version of microsoft-pr-metrics[bot] with [bot] on the end.

Both microsoft-pr-metrics[bot] and microsoft-pr-metrics appear in PRs. microsoft-pr-metrics is the app name. In login metadata that I get back from API results of a PR (which is likely what the GitOps app is reading), the form is microsoft-pr-metrics[bot]