### PR TITLE
Add new bots to CLA policy

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -43,6 +43,8 @@ configuration:
          - blackrobot
          - bot-for-go[bot]
          - business-central-bot[bot]
+         - business-central-bug-fix-bot[bot]
+         - business-central-extensibility-bot[bot]
          - CBL-Mariner-Bot
          - content-assistant[bot]
          - Copilot


### PR DESCRIPTION
[Business Central Bug Fix Bot](https://github.com/apps/business-central-bug-fix-bot) and [Business Central Extensibility Bot
](https://github.com/apps/business-central-extensibility-bot) are two newly added GitHub App used in [BCApps](https://github.com/microsoft/BCApps) to eliminate the need of PATs for various automations.